### PR TITLE
fix: 重复添加rect && 某些组件过大导致ocr不识别内部小组件

### DIFF
--- a/UIAnalyzer/PageCognition.py
+++ b/UIAnalyzer/PageCognition.py
@@ -91,6 +91,8 @@ class PageCognition:
         if enable_ocr:
             ocr = easyocr.Reader([lang, 'en'])
             filtered_xml_rects = filter_xml_rects()  # 2. Use OCR to filter XML Rects
+            if len(xml_rects) <= 5:
+                xml_rects = []
             ocr_rects = get_ocr_rects()  # 3. Add OCR Rects
             rects = filtered_xml_rects + ocr_rects
         else:

--- a/UIAnalyzer/PageCognition.py
+++ b/UIAnalyzer/PageCognition.py
@@ -40,16 +40,22 @@ class PageCognition:
                 if 'text' in xml_rect.keys():
                     if ocr_res:  # If there is any OCR result
                         if isinstance(xml_rect['text'], str):
+                            outer_break = False
                             for ocr_re in ocr_res:
+                                if outer_break:
+                                    break
                                 if calculate_levenshtein_similarity(xml_rect['text'], ocr_re['text']) > 0.5:
                                     ret_rects.append(xml_rect)
-                                    break
+                                    outer_break = True
                         else:
+                            outer_break = False
                             for text in xml_rect['text']:
+                                if outer_break:
+                                    break
                                 for ocr_re in ocr_res:
                                     if calculate_levenshtein_similarity(text, ocr_re['text']) > 0.5 or text in ocr_re['text']:
                                         ret_rects.append(xml_rect)
-                                        break
+                                        outer_break = True
                 else:
                     ret_rects.append(xml_rect)
             return ret_rects


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/89e07f3b-1a35-4c10-8dd9-01d4d5a4629c)
由于以下代码未能跳出外循环，导致text对象是多元列表时，造成重复添加的情况。
https://github.com/bz-UI/UIAnalyzer/blob/88aaa77c1b195e1f31aa9957177ad2f3ba29386e/UIAnalyzer/PageCognition.py#L40-L52